### PR TITLE
Support new source names #10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,6 @@ Run ``pip install sphinxprettysearchresults``.
 
 Configuration
 -------------
-There are no custom configuration variables for the *Sphinx: pretty search results* extension.
-
 After installing the extension, all you need to do is to register it.
 
 Add ``sphinxprettysearchresults`` to the ``extensions`` array in your ``conf.py`` file, for example::
@@ -30,6 +28,15 @@ Add ``sphinxprettysearchresults`` to the ``extensions`` array in your ``conf.py`
    ]
 
 After your next build, your project will no longer display raw markup in the search result excerpts.
+
+Since version 1.5.0, Sphinx is adding the source file extension to the source files it includes in the output folder.
+For example, when your source file extension is `rst` (specified in the config variable `source_suffix` as `[.rst]`,
+your index file appears in the output's source folder as `index.rst.txt`. If you use a Sphinx version lower than 1.5.0,
+it appears as `index.txt`. *Sphinx: pretty search results* considers this difference and changes its behavior according
+to your Sphinx version. However, if you use a Sphinx theme that expects the old file names although you are using a
+later Sphinx version, you can fall back to the old file names by setting the following configuration variable::
+
+   use_old_search_snippets = True
 
 
 Testing

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import codecs, setuptools
 setuptools.setup(
     name='sphinxprettysearchresults',
     packages=['sphinxprettysearchresults'],
-    version='0.1.7',
+    version='0.2.0',
     description='Decently styled search results for sphinx-doc projects',
     author='Timotheus Kampik',
     author_email='timotheus.kampik@gmail.com',

--- a/sphinxprettysearchresults/__init__.py
+++ b/sphinxprettysearchresults/__init__.py
@@ -1,4 +1,4 @@
-import shutil, subprocess
+import os, pkg_resources, shutil, subprocess
 import docutils
 
 from docutils import nodes
@@ -6,7 +6,7 @@ from docutils import nodes
 from docutils.nodes import *
 
 
-def clean_txts(language, srcdir, outdir):
+def clean_txts(language, srcdir, outdir, source_suffix, use_old_search_snippets):
     if not isinstance(outdir, str) and isinstance(outdir, unicode):
         outdir = outdir.encode('UTF-8')
 
@@ -27,13 +27,23 @@ def clean_txts(language, srcdir, outdir):
 
     build_txt = subprocess.Popen(['sphinx-build', '-a', '-b', 'text','-D' 'language=' + language, \
                                   srcdir, sources_build_path])
+
     build_txt.wait()
+
     shutil.move(sources_build_path, sources_path)
+
+    if pkg_resources.get_distribution("sphinx").version >= "1.5.0" and not use_old_search_snippets:
+        for root, dirs, files in os.walk(sources_path):
+            for file in files:
+                if source_suffix == '.txt':
+                    source_suffix = ''
+                os.rename(os.path.join(root, file), os.path.join(root, file.replace('.txt', source_suffix + '.txt')))
 
 
 def build_search_snippets(app, docname):
     if app.builder.name == 'html':
-        clean_txts(app.config.language, app.srcdir, app.outdir)
+        source_suffix = app.config.source_suffix[0]
+        clean_txts(app.config.language, app.srcdir, app.outdir, source_suffix, app.config.use_old_search_snippets)
 
 
 def remove_text_markup(app, doctree, docname):
@@ -60,5 +70,6 @@ def remove_text_markup(app, doctree, docname):
 
 
 def setup(app):
+    app.add_config_value('use_old_search_snippets', False, 'html')
     app.connect('build-finished', build_search_snippets)
     app.connect('doctree-resolved', remove_text_markup)


### PR DESCRIPTION
Since version 1.5.0, Sphinx is adding the source file extension to the source files it includes in the output folder.
For example, when your source file extension is `rst` (specified in the config variable `source_suffix` as `[.rst]`, your index file appears in the output's source folder as `index.rst.txt`.
If you use a Sphinx version lower than 1.5.0, it appears as `index.txt`.
Here's the link to the PR that introduces the breaking change: sphinx-doc/sphinx#2454.

The solution adjust the file name/suffix based on the Sphinx version:

* If you use Sphinx >=1.5, the file name will be filename + source_file_ending + ".txt".
* If you use Sphinx < 1.5, the file name will be filename + ".txt".

The changes also add aconfig option that allows forcing a fallback to 2).
This will help folks who use this extension for a long time and whose templates evolved accordingly.