### PR TITLE
 #12 support page source links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.egg-info
 .idea/
+venv/
 dist/
 tests/root/_build

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,8 @@
 
 Sphinx: pretty search results
 =============================
-*Sphinx: pretty search results* is an extension for the `Sphinx documentation tool <http://www.sphinx-doc.org/en/stable/>`__.
+*Sphinx: pretty search results* is an extension for the
+`Sphinx documentation tool <http://www.sphinx-doc.org/en/stable/>`__.
 
 To display search results, Sphinx is fetching the source files of search hits and rendering excerpts in raw markup
 (`Example <http://www.sphinx-doc.org/en/stable/search.html?q=quickstart&check_keywords=yes&area=default>`__).
@@ -39,9 +40,18 @@ later Sphinx version, you can fall back to the old file names by setting the fol
    use_old_search_snippets = True
 
 
+Source links
+------------
+By default Sphinx copies the source files into the build's `_sources` directory and uses it for both search snippets and
+- if `activated <http://www.sphinx-doc.org/en/stable/config.html#confval-html_show_sourcelink>`_ - source links.
+*Sphinx: pretty search results* uses the `_sources` directory for the prettified text snippets and moves the raw sources
+(for the source links) into its own `_raw_sources` directory. On build time, it overwrites the `sourcelink.html`
+template to reference the files in `_raw_sources`. This means you cannot use the extension with a custom
+`sourcelink.html` template.
+
 Testing
 -------
-*Sphinx: pretty search results* uses `nose <https://github.com/nose-devs/nose>`__ as a test framework.
+*Sphinx: pretty search results* uses `nose <https://github.com/nose-devs/nose>`__ as its test framework.
 
 To run the tests, you first need to install the dev dependencies::
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import codecs, setuptools
 setuptools.setup(
     name='sphinxprettysearchresults',
     packages=['sphinxprettysearchresults'],
-    version='0.2.0',
+    version='0.3.0',
     description='Decently styled search results for sphinx-doc projects',
     author='Timotheus Kampik',
     author_email='timotheus.kampik@gmail.com',

--- a/sphinxprettysearchresults/__init__.py
+++ b/sphinxprettysearchresults/__init__.py
@@ -5,6 +5,8 @@ from docutils import nodes
 
 from docutils.nodes import *
 
+from sphinx.jinja2glue import SphinxFileSystemLoader
+
 
 def clean_txts(language, srcdir, outdir, source_suffix, use_old_search_snippets):
     if not isinstance(outdir, str) and isinstance(outdir, unicode):
@@ -17,7 +19,7 @@ def clean_txts(language, srcdir, outdir, source_suffix, use_old_search_snippets)
     sources_build_path = '_build_txt'
 
     if os.path.isdir(sources_path):
-        shutil.rmtree(sources_path)
+        shutil.move(sources_path, outdir + '/_raw_sources')
 
     if not os.path.isdir(sources_build_path):
         os.makedirs(sources_build_path)
@@ -69,7 +71,14 @@ def remove_text_markup(app, doctree, docname):
             node.replace_self(docutils.nodes.line('',''))
 
 
+def add_custom_source_link(app):
+    # load custom source link template
+    if app.builder.name == 'html':
+        app.builder.templates.loaders.insert(0, SphinxFileSystemLoader(os.path.dirname(__file__)))
+
+
 def setup(app):
     app.add_config_value('use_old_search_snippets', False, 'html')
     app.connect('build-finished', build_search_snippets)
     app.connect('doctree-resolved', remove_text_markup)
+    app.connect('builder-inited', add_custom_source_link)

--- a/sphinxprettysearchresults/sourcelink.html
+++ b/sphinxprettysearchresults/sourcelink.html
@@ -1,0 +1,13 @@
+{#
+    because we now have actual and prettified sources,
+    this plugin introduces a custom source link that points to the new location of the non-prettified sources
+#}
+{%- if show_source and has_source and sourcename %}
+  <div role="note" aria-label="source link">
+    <h3>{{ _('This Page') }}</h3>
+    <ul class="this-page-menu">
+      <li><a href="{{ pathto('_raw_sources/' + sourcename, true)|e }}"
+            rel="nofollow">{{ _('Show Source') }}</a></li>
+    </ul>
+   </div>
+{%- endif %}


### PR DESCRIPTION
Previously, the extension would overwrite the source files Sphinx copies to the
build result. This is a problem for projects that have the property
[html_show_sourcelink](http://www.sphinx-doc.org/en/stable/config.html#confval-html_show_sourcelink)
activated.
This commit fixes the issue by introducing a second directory for "raw" source
files.
Also see the changes I made to the README.